### PR TITLE
feat: cleaner generated topography mesh

### DIFF
--- a/global_main.py
+++ b/global_main.py
@@ -154,7 +154,11 @@ def main(args):
     os.makedirs(sfm_dir, exist_ok=True)
     combined_rec.write(sfm_dir)
     
-    logger.info(f"Exporting colmap points to PLY...")
+    logger.info(f"Exporting colmap points to PLY")
+    obs = pycolmap.ObservationManager(combined_rec)
+    filtered_count = obs.filter_all_points3D(max_reproj_error=4.0, min_tri_angle=2.0)
+    logger.info(f"Filtered {filtered_count} points with large reprojection error or low triangulation angle.")
+    logger.info(f"Filtered reconstruction for PLY export: {combined_rec}")
     ply_path = output_path / "RefinedPointCloud.ply"
     combined_rec.export_PLY(ply_path) # Outputs binary PLY in openCV coords. We convert it to OpenGL in the post_process_ply
     logger.info(f"PLY exported -> {ply_path}")

--- a/main.py
+++ b/main.py
@@ -140,8 +140,8 @@ def global_main_wrapper(args, logger):
         input_path=global_args.output_path / "RefinedPointCloud.ply",
         output_dir=global_args.output_path / "topology",
         floor_height=0.0,
-        floor_height_threshold=0.35,
-        voxel_size=0.1
+        floor_height_threshold=0.3,
+        voxel_size=0.05
     )
 
     topology_main(topology_args, logger)

--- a/topology_main.py
+++ b/topology_main.py
@@ -7,8 +7,6 @@ import numpy as np
 import time
 import logging
 import sys
-from sklearn.cluster import DBSCAN
-import shutil
 from colorsys import hsv_to_rgb
 
 
@@ -75,26 +73,32 @@ def main(args, logger=None):
     pcd = o3d.geometry.PointCloud()
     pcd.points = o3d.utility.Vector3dVector(above_floor)
 
+    with timed_section_scope("Voxel Downsampling", logger):
+        old_count = len(pcd.points)
+        pcd = pcd.voxel_down_sample(voxel_size=args.voxel_size)
+        logger.info(f"Downsampled using voxel size {args.voxel_size}, from {old_count} to {len(pcd.points)} points")
+
     with timed_section_scope("Outlier Removal", logger):
         old_count = len(pcd.points)
-        [pcd, _] = pcd.remove_statistical_outlier(
-            nb_neighbors=20, std_ratio=2.0
-        )
-        logger.info(f"Removed {len(pcd.points) - old_count} outlier points")
+        [pcd, _] = pcd.remove_statistical_outlier(nb_neighbors=10, std_ratio=2.5)
+        logger.info(f"Removed {old_count - len(pcd.points)} outlier points")
 
     meshes = []
     with timed_section_scope("Clustering", logger):
         logger.info(f"Clustering 'above floor' points")
 
-        labels = pcd.cluster_dbscan(eps=0.25, min_points=20)
+        labels = pcd.cluster_dbscan(eps=0.35, min_points=100)
         unique_labels = np.unique(labels)
         unique_labels = unique_labels[unique_labels != -1] # -1 are points which didn't end up in any cluster
 
         logger.info(f"Found {len(unique_labels)} clusters")
 
+        total_points_in_any_cluster = 0
+        floating_in_air_clusters = 0
+        too_few_points_clusters = 0
+        too_flat_clusters = 0
         for label in unique_labels:
             cluster_points = np.array(pcd.points)[labels == label]
-            logger.info(f"Cluster {label} has {len(cluster_points)} points")
 
             cluster_pcd = o3d.geometry.PointCloud()
             cluster_pcd.points = o3d.utility.Vector3dVector(cluster_points)
@@ -102,68 +106,40 @@ def main(args, logger=None):
             invalid = False
             if len(cluster_points) < 100:
                 invalid = True
-                logger.info(f"Skip cluster {label}: Too few points")
+                too_few_points_clusters += 1
+                logger.debug(f"Skip cluster {label}: Too few points (count: {len(cluster_points)})")
             else:
-                bounding_box = cluster_pcd.get_oriented_bounding_box()
+                bounding_box = cluster_pcd.get_axis_aligned_bounding_box()
                 bounding_box_min_y = bounding_box.get_min_bound()[1]
-                if bounding_box_min_y > args.floor_height + 0.5:
+                if bounding_box_min_y > args.floor_height + args.floor_height_threshold + 0.5:
                     invalid = True
-                    logger.info(f"Skip cluster {label}: Floating in air")
+                    floating_in_air_clusters += 1
+                    logger.debug(f"Skip cluster {label}: Floating in air (count: {len(cluster_points)}, lowest Y: {bounding_box_min_y:.3f})")
                 else:
                     bounding_box_max_y = bounding_box.get_max_bound()[1]
                     if bounding_box_max_y - bounding_box_min_y < 0.2:
                         invalid = True
-                        logger.info(f"Skip cluster {label}: Too flat")
+                        too_flat_clusters += 1
+                        logger.debug(f"Skip cluster {label}: Too flat (count: {len(cluster_points)}, height: {bounding_box_max_y - bounding_box_min_y:.3f})")
 
             if invalid:
                 continue
 
-            color = hsv_to_rgb(((label * 3) % len(unique_labels)) / len(unique_labels), 0.75, 1.0)
+            logger.debug(f"Keeping cluster {label} with {len(cluster_points)} points")
+            total_points_in_any_cluster += len(cluster_points)
 
-            # Three step approach for a tight fit without holes, around a noisy sparse point cloud
-            # 1. Create low poly alpha mesh first to avoid holes and get good outward-facing normals
-            # 2. Subdivide to more polygons
-            # 3. "shrink wrap": snap each vertex onto the point cloud nearby.
-            lowpoly = o3d.geometry.TriangleMesh.create_from_point_cloud_alpha_shape(cluster_pcd, alpha=0.7)
-            lowpoly = lowpoly.filter_smooth_simple(number_of_iterations=1)
-            lowpoly.compute_vertex_normals()
-            
-            highpoly = lowpoly.subdivide_midpoint(number_of_iterations=2)
+            color = hsv_to_rgb(float((label * 3) % len(unique_labels)) / len(unique_labels), 0.75, 1.0)
+            mesh = o3d.geometry.TriangleMesh.create_from_point_cloud_alpha_shape(cluster_pcd, alpha=0.25)
 
-            pointcloud_search_tree = o3d.geometry.KDTreeFlann(cluster_pcd) # For fast querying of nearby points many times
-            snapped_count = 0
-            snapped_distance_sum = 0.0
-            not_snapped_count = 0
-            for i in range(len(highpoly.vertices)):
-                vertex = highpoly.vertices[i]
+            mesh.paint_uniform_color(color)
+            meshes.append(mesh)
 
-                # Snap the vertex onto point cloud (basically 'shink-wrapping' the alpha shape tigher to the point cloud without introducing holes)
-                # IMPORTANT: Snap to the average of several nearby points to ignore outlier points better.
-                _, neighbor_indices, _ = pointcloud_search_tree.search_hybrid_vector_3d(vertex, 0.3, 7)
-                if len(neighbor_indices) < 5:
-                    # Try again with bigger radius
-                    _, neighbor_indices, _ = pointcloud_search_tree.search_hybrid_vector_3d(vertex, 0.5, 10)
-                    if len(neighbor_indices) == 0:
-                        not_snapped_count += 1
-                        continue
-
-                neighbor_points = cluster_points[neighbor_indices]
-                middle_point = np.mean(neighbor_points, axis=0)
-                
-                snapped_distance_sum += np.linalg.norm(vertex - middle_point) # Just for stats logging
-                highpoly.vertices[i] = middle_point
-                snapped_count += 1
-
-            logger.info(f"Snapped {snapped_count} vertices onto point cloud. Average distance: {snapped_distance_sum / snapped_count:.4f}. {not_snapped_count} vertices not snapped.")
-
-            cluster_mesh = highpoly
-            cluster_mesh = cluster_mesh.filter_smooth_simple(number_of_iterations=2)
-            cluster_mesh = cluster_mesh.simplify_quadric_decimation(target_number_of_triangles=len(cluster_mesh.triangles) // 4)
-            cluster_mesh.compute_vertex_normals()
-            cluster_mesh.paint_uniform_color(color)
-            meshes.append(cluster_mesh)
+    total_skipped_clusters = too_few_points_clusters + floating_in_air_clusters + too_flat_clusters
+    logger.info(f"Skipped {total_skipped_clusters} clusters (too few points: {too_few_points_clusters}, floating in air: {floating_in_air_clusters}, too flat: {too_flat_clusters})")
+    logger.info(f"Kept {len(unique_labels) - total_skipped_clusters} clusters with a total of {total_points_in_any_cluster} points")
 
     if meshes:
+        logger.info(f"Merging {len(meshes)} cluster meshes into a single mesh")
         with timed_section_scope("Merging meshes", logger):
             merged_mesh = o3d.geometry.TriangleMesh()
             for mesh in meshes:


### PR DESCRIPTION
Made some simplifications on the topography mesh generation, which didn't work well previously. Now it should be a bit cleaner not getting "glued together" between separate walls. It will still contain some holes and miss some geometry wherever the point cloud is less dense. This is OK for now and could be improved later by for example introducing monocular depth densification or other densification methods.

Also this should run a bit faster now since 1. actually doing the voxelization, meaning fewer points to cluster etc,
and also 2. removing the extra loop of snapping to point cloud.