### PR TITLE
fix: draco encoding pointcloud not working

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -149,7 +149,8 @@ RUN set -eux; \
     cd /tmp/build; \
     git clone --recursive https://github.com/aukilabs/Hierarchical-Localization.git; \
     cd Hierarchical-Localization; \
-    git checkout --recurse-submodules a698de1a09604b31a42ec21c95419018430a5db4; \
+    git checkout --recurse-submodules 87b266cdb3a894455a9c889276f4e5d5913eb0eb; \
+    pip install torch==2.9.1 torchvision==0.24.1 torchaudio==2.9.1 --index-url https://download.pytorch.org/whl/cu128; \
     python3 -m pip install .; \
     cd /; \
     rm -rf /tmp/build/*
@@ -161,8 +162,9 @@ RUN set -eux; \
     cd draco; \
     mkdir build; \
     cd build; \
-    cmake .. -GNinja; \
+    cmake .. -GNinja -DCMAKE_INSTALL_PREFIX=/usr/local; \
     ninja -j"$(nproc)"; \
+    ninja install; \
     cd /; \
     rm -rf /tmp/build/*
 

--- a/utils/point_cloud_utils.py
+++ b/utils/point_cloud_utils.py
@@ -108,7 +108,9 @@ def filter_point_cloud(point_cloud, ply_remove_outliers=True, ply_downsample=Tru
 def draco_compress_ply(ply_path, draco_path, logger=None):
     # Command line tool (already compiled)
     # Quantizing with 13 bits, empirically selected for no visual difference.
-    subprocess.run(["/src/draco/build/draco_encoder", "-i", ply_path, "-qp", "13", "-o", draco_path])
+    subprocess.run(
+        ["/usr/local/bin/draco_encoder", "-i", ply_path, "-qp", "13", "-o", draco_path]
+    )
 
     if logger is not None:
         logger.info(f"Draco compressed point cloud saved: {draco_path}")


### PR DESCRIPTION
Since we restructured the docker files in v0.3.0, the draco compression of point cloud PLY didn't work. The jobs still succeeded though since the non-compressed ply still worked and the draco was an optional output.

The draco compressed PLY is desired since it is much smaller, and also the normal PLY gets downsampled to fewer points if needed to fit in 20 MB (so it doesn't take too long to load).

The base dockerfile was building the draco codebase into its folder and then just deleting it. Now it instead installs into another folder to ensure it stays into the built final image, even after the cloned draco source is removed.

HOWEVER, after re-building the base image I got a bunch of other new issues caused by newer torch versions being used vs the previous build. I pin the same stable torch version for now as we had in the previous base image. We should probably upgrade this later but I want to avoid breaking compatibility right now as I first ran into driver version errors from torch on my machine.

The changes in newer torch also meant you have to provide "trusted repo" into the torch hub download calls, otherwise it just won't download the Eigenplace model. I updated the aukilabs fork of hloc to also provide trust_repo=True in the eigenplaces.py. This was loading however a thirdparty github repo which could be potentionally a risk as it executes code from that other repo (even though they seem very credible). So I also made forks of of the 3rd party repos, [EigenPlaces](https://github.com/aukilabs/EigenPlaces) and [CosPlace](https://github.com/aukilabs/CosPlace).
This is the only change in the new hloc commit we checkout now.