### PR TITLE
chore: quality-of-life improvements for local development & debugging

### DIFF
--- a/global_main.py
+++ b/global_main.py
@@ -91,7 +91,8 @@ def main(args):
         log_file=global_log_file,
         domain_id=args.domain_id, 
         job_id=args.job_id, 
-        level=args.log_level
+        level=args.log_level,
+        log_format=args.log_format
     )
 
     # Find all stitch paths

--- a/local_main.py
+++ b/local_main.py
@@ -27,6 +27,7 @@ def main(args, pool_executor=None):
         args.domain_id,
         args.job_id,
         args.log_level,
+        args.log_format,
         pool_executor=pool_executor
     )
 
@@ -55,6 +56,7 @@ if __name__ == "__main__":
         choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
         help="Set the logging level (default: INFO)"
     )
+    parser.add_argument('--log_format', choices=["text", "json"], default="json", help="Log output format (text or json)")
     args = parser.parse_args()
 
     main(args)

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import argparse
+import re
 from concurrent.futures import ProcessPoolExecutor
 
 from local_main import main as local_main
@@ -8,6 +9,33 @@ from topology_main import main as topology_main
 from occlusion_box import main as occlusion_main
 from utils.data_utils import save_failed_manifest_json, setup_logger
 from utils.io import load_yaml, save_to_yaml
+
+def infer_domain_and_job_from_job_root(job_root_path: Path) -> tuple[str, str] | None:
+    """If job_root_path ends with <domain_uuid>/job_<uuid>, return (domain_id, job_id)."""
+
+    if job_root_path is None:
+        return None
+
+    
+
+    parts = job_root_path.parts
+    if len(parts) < 2:
+        return None
+
+    _JOB_ROOT_JOB_SEGMENT_RE = re.compile(
+        r"^job_[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+    )
+    _DOMAIN_ID_RE = re.compile(
+        r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+    )
+
+    domain_candidate, job_candidate = parts[-2], parts[-1]
+    if not _DOMAIN_ID_RE.fullmatch(domain_candidate):
+        return None
+    if not _JOB_ROOT_JOB_SEGMENT_RE.fullmatch(job_candidate):
+        return None
+
+    return domain_candidate, job_candidate
 
 
 def occlusion_box_wrapper(pointcloud_path, output_dir, logger):
@@ -50,7 +78,8 @@ def process_local_refinement(args, scan, worker_pool=None):
         remove_outputs=False,
         domain_id=args.domain_id,
         job_id=args.job_id,
-        log_level=args.log_level
+        log_level=args.log_level,
+        log_format=args.log_format
     )
     return local_main(local_args, worker_pool)
 
@@ -125,7 +154,8 @@ def global_main_wrapper(args, logger):
         ply_remove_outliers=True,
         domain_id=args.domain_id,
         job_id=args.job_id,
-        log_level=args.log_level
+        log_level=args.log_level,
+        log_format=args.log_format
     )
     global_main(global_args)
     logger.info("Done with global refinement")
@@ -229,7 +259,8 @@ def main(args):
         log_file=args.job_root_path / 'log.txt', 
         domain_id=args.domain_id, 
         job_id=args.job_id, 
-        level=args.log_level
+        level=args.log_level,
+        log_format=args.log_format
     )
 
     # The runner currently derives scans from datasets to avoid stale client-provided scan lists.
@@ -247,9 +278,9 @@ def main(args):
 
 def parse_args():
     parser = argparse.ArgumentParser(description="SfM refinement script")
-    parser.add_argument("--domain_id", type=str, default="00000000-0000-0000-0000-000000000000", help="Domain ID for logging")
-    parser.add_argument("--job_id", type=str, default="job_00000000-0000-0000-0000-000000000000", help="Job ID for logging")
-    parser.add_argument("--mode", choices=["local_refinement", "global_refinement", "local_and_global_refinement"], help="Refinement mode")
+    parser.add_argument("--domain_id", type=str, default=None, help="Domain ID for logging")
+    parser.add_argument("--job_id", type=str, default=None, help="Job ID for logging")
+    parser.add_argument("--mode", choices=["local_refinement", "global_refinement", "local_and_global_refinement"], default="local_and_global_refinement", help="Refinement mode")
     parser.add_argument("--job_root_path", type=Path, help="Path to the job root (parent of 'datasets' sub-folder with all scans inside)")
     parser.add_argument("--output_path", type=Path, help="Path for output")
     parser.add_argument("--local_refinement_workers", type=int, default=0,
@@ -258,9 +289,20 @@ def parse_args():
     parser.add_argument("--log_level", type=str, default="INFO", choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
         help="Set the logging level (default: INFO)"
     )
+    parser.add_argument("--log_format", choices=["text", "json"], default="json", help="Log output format (text or json)")
 
     parser.add_argument("--scans", nargs="+", default=[], help="List of scans to process")
-    return parser.parse_args()
+    args = parser.parse_args()
+    if args.job_root_path and not args.domain_id and not args.job_id:
+        inferred_ids = infer_domain_and_job_from_job_root(args.job_root_path)
+        if inferred_ids:
+            args.domain_id, args.job_id = inferred_ids
+            print("Inferred domain_id from job_root_path: ", args.domain_id)
+            print("Inferred job_id from job_root_path: ", args.job_id)
+    
+    if not args.domain_id or not args.job_id:
+        parser.error("domain_id and/or job_id were not supplied, and could not be inferred from job_root_path")
+    return args
 
 
 if __name__ == "__main__":

--- a/server/rust/runner-reconstruction-global/src/lib.rs
+++ b/server/rust/runner-reconstruction-global/src/lib.rs
@@ -82,6 +82,14 @@ impl Default for RunnerReconstructionGlobal {
     }
 }
 
+/// When true, the job workspace directory is left on disk after the task finishes (same env semantics as splatter-server).
+fn tasks_cleanup_disabled() -> bool {
+    match env::var("DISABLE_TASKS_CLEANUP") {
+        Ok(v) => matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"),
+        Err(_) => false,
+    }
+}
+
 #[async_trait::async_trait]
 impl Runner for RunnerReconstructionGlobal {
     fn capability(&self) -> &'static str {
@@ -101,14 +109,23 @@ impl Runner for RunnerReconstructionGlobal {
             anyhow::bail!("task cancelled before execution");
         }
 
-        let workspace = self.create_workspace(&domain_id, job_id.as_deref(), &task_id)?;
+        let mut workspace = self.create_workspace(&domain_id, job_id.as_deref(), &task_id)?;
+        let retain_workspace_after_run = tasks_cleanup_disabled();
+        if retain_workspace_after_run {
+            workspace.persist_temp_base();
+        }
+        // By default remove the workspace on exit; set DISABLE_TASKS_CLEANUP to retain it for debugging.
         struct WorkspaceCleanup(std::path::PathBuf);
         impl Drop for WorkspaceCleanup {
             fn drop(&mut self) {
                 let _ = std::fs::remove_dir_all(&self.0);
             }
         }
-        let _workspace_cleanup = WorkspaceCleanup(workspace.root().to_path_buf());
+        let _workspace_cleanup = if retain_workspace_after_run {
+            None
+        } else {
+            Some(WorkspaceCleanup(workspace.root().to_path_buf()))
+        };
 
         let job_ctx = JobContext::from_lease(lease)?;
         job_ctx
@@ -127,6 +144,7 @@ impl Runner for RunnerReconstructionGlobal {
                 .as_ref()
                 .map(|p| p.display().to_string())
                 .unwrap_or_else(|| "<temp>".into()),
+            retain_workspace_after_run = retain_workspace_after_run,
             "workspace prepared"
         );
         let _ = ctx

--- a/server/rust/runner-reconstruction-global/src/workspace.rs
+++ b/server/rust/runner-reconstruction-global/src/workspace.rs
@@ -67,7 +67,7 @@ impl Workspace {
     /// Call this when retaining files on disk (e.g. `DISABLE_TASKS_CLEANUP`) so the base directory is not removed on drop.
     pub fn persist_temp_base(&mut self) {
         if let Some(dir) = self._temp_guard.take() {
-            let _ = dir.into_path();
+            let _ = dir.keep();
         }
     }
 

--- a/server/rust/runner-reconstruction-global/src/workspace.rs
+++ b/server/rust/runner-reconstruction-global/src/workspace.rs
@@ -63,6 +63,14 @@ impl Workspace {
         })
     }
 
+    /// When the workspace used a [`TempDir`] base, dropping `Self` would delete the entire tree.
+    /// Call this when retaining files on disk (e.g. `DISABLE_TASKS_CLEANUP`) so the base directory is not removed on drop.
+    pub fn persist_temp_base(&mut self) {
+        if let Some(dir) = self._temp_guard.take() {
+            let _ = dir.into_path();
+        }
+    }
+
     /// Root directory for the job workspace.
     pub fn root(&self) -> &Path {
         &self.root

--- a/server/rust/runner-reconstruction-local/src/lib.rs
+++ b/server/rust/runner-reconstruction-local/src/lib.rs
@@ -88,6 +88,14 @@ fn load_config() -> RunnerConfig {
     })
 }
 
+/// When true, the job workspace directory is left on disk after the task finishes (same env semantics as splatter-server).
+fn tasks_cleanup_disabled() -> bool {
+    match env::var("DISABLE_TASKS_CLEANUP") {
+        Ok(v) => matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"),
+        Err(_) => false,
+    }
+}
+
 #[async_trait::async_trait]
 impl Runner for RunnerReconstructionLocal {
     fn capability(&self) -> &'static str {
@@ -107,15 +115,23 @@ impl Runner for RunnerReconstructionLocal {
             anyhow::bail!("task cancelled before execution");
         }
 
-        let workspace = self.create_workspace(&domain_id, job_id.as_deref(), &task_id)?;
-        // Ensure stateless behavior: schedule workspace cleanup on function exit (success or error).
+        let mut workspace = self.create_workspace(&domain_id, job_id.as_deref(), &task_id)?;
+        let retain_workspace_after_run = tasks_cleanup_disabled();
+        if retain_workspace_after_run {
+            workspace.persist_temp_base();
+        }
+        // By default remove the workspace on exit; set DISABLE_TASKS_CLEANUP to retain it for debugging.
         struct WorkspaceCleanup(std::path::PathBuf);
         impl Drop for WorkspaceCleanup {
             fn drop(&mut self) {
                 let _ = std::fs::remove_dir_all(&self.0);
             }
         }
-        let _workspace_cleanup = WorkspaceCleanup(workspace.root().to_path_buf());
+        let _workspace_cleanup = if retain_workspace_after_run {
+            None
+        } else {
+            Some(WorkspaceCleanup(workspace.root().to_path_buf()))
+        };
 
         let job_ctx = JobContext::from_lease(lease)?;
         job_ctx
@@ -134,6 +150,7 @@ impl Runner for RunnerReconstructionLocal {
                 .as_ref()
                 .map(|p| p.display().to_string())
                 .unwrap_or_else(|| "<temp>".into()),
+            retain_workspace_after_run = retain_workspace_after_run,
             "workspace prepared"
         );
         let _ = ctx

--- a/server/rust/runner-reconstruction-local/src/workspace.rs
+++ b/server/rust/runner-reconstruction-local/src/workspace.rs
@@ -59,6 +59,14 @@ impl Workspace {
         })
     }
 
+    /// When the workspace used a [`TempDir`] base, dropping `Self` would delete the entire tree.
+    /// Call this when retaining files on disk (e.g. `DISABLE_TASKS_CLEANUP`) so the base directory is not removed on drop.
+    pub fn persist_temp_base(&mut self) {
+        if let Some(dir) = self._temp_guard.take() {
+            let _ = dir.into_path();
+        }
+    }
+
     /// Root directory for the job workspace.
     pub fn root(&self) -> &Path {
         &self.root

--- a/server/rust/runner-reconstruction-local/src/workspace.rs
+++ b/server/rust/runner-reconstruction-local/src/workspace.rs
@@ -63,7 +63,7 @@ impl Workspace {
     /// Call this when retaining files on disk (e.g. `DISABLE_TASKS_CLEANUP`) so the base directory is not removed on drop.
     pub fn persist_temp_base(&mut self) {
         if let Some(dir) = self._temp_guard.take() {
-            let _ = dir.into_path();
+            let _ = dir.keep();
         }
     }
 

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -885,7 +885,7 @@ class JsonFormatter(logging.Formatter):
         return json.dumps(record_dict)
 
 
-def setup_logger(name=None, log_file=None, domain_id="", job_id="", dataset_id=None, level="INFO"):
+def setup_logger(name=None, log_file=None, domain_id="", job_id="", dataset_id=None, level="INFO", log_format="json"):
     """To setup as many loggers as you want"""
 
     logger = logging.getLogger(name)
@@ -899,8 +899,23 @@ def setup_logger(name=None, log_file=None, domain_id="", job_id="", dataset_id=N
         logger, _ = add_file_handler(logger, log_file)
 
     console_handler = logging.StreamHandler()
-    console_handler.setFormatter(JsonFormatter(datefmt='%Y-%m-%dT%H:%M:%S',
-        domain_id=domain_id, job_id=job_id, dataset_id=dataset_id))
+    if log_format == "json":
+        console_handler.setFormatter(
+            JsonFormatter(
+                datefmt='%Y-%m-%dT%H:%M:%S',
+                domain_id=domain_id,
+                job_id=job_id,
+                dataset_id=dataset_id
+            )
+        )
+    else:
+        console_handler.setFormatter(
+            logging.Formatter(
+                fmt='%(asctime)s %(name)s %(levelname)s %(message)s'
+            )
+        )
+       
+
     logger.addHandler(console_handler)
 
     return logger

--- a/utils/refinement_util.py
+++ b/utils/refinement_util.py
@@ -287,6 +287,7 @@ def refine_dataset(
     domain_id="",
     job_id="",
     log_level="INFO",
+    log_format="json",
     pool_executor=None
 ):
     """
@@ -300,6 +301,7 @@ def refine_dataset(
         domain_id: Domain identifier
         job_id: Job identifier
         log_level: Logging level
+        log_format: Logging format
         pool_executor: ThreadPoolExecutor instance for parallel processing
     Returns:
         Future object if pool_executor is provided, otherwise None
@@ -318,7 +320,8 @@ def refine_dataset(
         domain_id=domain_id, 
         job_id=job_id, 
         dataset_id=scan_folder_path.name,
-        level=log_level
+        level=log_level,
+        log_format=log_format
     )
     logger.info(f'Starting local refinement of {scan_folder_path.name}')
 


### PR DESCRIPTION
Multiple changes for easy iterating on the python code locally during development:

- Added --log_format flag to choose text or json. Default is json as before.
Passing --log_format text when running the python scripts locally makes the debug output less cluttered.

- Make the --mode flag optional, defaulting to 'local_and_global_refinement'.
Rust code still always passes the mode flag, but when running locally it's convenient to have it be optional.

- If not provided, --domain_id and --job_id are automatically inferred from the path passed into --job_root_path.
This makes it easier to re-run main.py on a local job folder.

- Config support for disabling the local jobs folder cleanup.
  Set environment variable DISABLE_TASKS_CLEANUP=1 to prevent server from deleting the local folder afterwards.

The above changes enable a convenient developer workflow:
1. Run the compute node
2. Send a job to it from DMT
3. Stop the compute node when job is done
4. Run `python main.py --job_root_path jobs/some_domain_id/job_some_task_id/` to run python refinement code.
5. Local development changes on the python code, easy to iterate.
