### PR TITLE
fix: ignore upload failures for non-mandatory refinement outputs

### DIFF
--- a/server/rust/runner-reconstruction-global/src/output.rs
+++ b/server/rust/runner-reconstruction-global/src/output.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use compute_runner_api::runner::{DomainArtifactContent, DomainArtifactRequest};
 use compute_runner_api::ArtifactSink;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::workspace::Workspace;
 
@@ -131,19 +131,35 @@ pub async fn upload_final_outputs(
         } else {
             None
         };
-        sink.put_domain_artifact(DomainArtifactRequest {
-            rel_path: spec.relative_path,
-            name: &name,
-            data_type: data_type_for_display(spec.display_name),
-            existing_id,
-            content: DomainArtifactContent::File(&path),
-        })
-        .await
-        .with_context(|| format!("upload output {}", spec.display_name))?;
-        uploaded.insert(
-            spec.display_name.to_string(),
-            spec.relative_path.to_string(),
-        );
+        match sink
+            .put_domain_artifact(DomainArtifactRequest {
+                rel_path: spec.relative_path,
+                name: &name,
+                data_type: data_type_for_display(spec.display_name),
+                existing_id,
+                content: DomainArtifactContent::File(&path),
+            })
+            .await
+        {
+            Ok(_) => {
+                uploaded.insert(
+                    spec.display_name.to_string(),
+                    spec.relative_path.to_string(),
+                );
+            }
+            Err(err) if !spec.mandatory => {
+                warn!(
+                    error = %err,
+                    display = spec.display_name,
+                    rel_path = spec.relative_path,
+                    size_bytes = size,
+                    "optional output upload failed; continuing"
+                );
+            }
+            Err(err) => {
+                return Err(err).with_context(|| format!("upload output {}", spec.display_name));
+            }
+        }
     }
 
     upload_json_if_exists(sink, "outputs_index.json", workspace.root(), name_suffix).await?;
@@ -180,19 +196,28 @@ async fn upload_json_if_exists(
     );
     if let Some((name, data_type)) = crate::strategy::describe_known_output(file_name, name_suffix)
     {
-        sink.put_domain_artifact(DomainArtifactRequest {
-            rel_path: file_name,
-            name: &name,
-            data_type: &data_type,
-            existing_id: None,
-            content: DomainArtifactContent::Bytes(&bytes),
-        })
-        .await
-        .with_context(|| format!("upload output {}", file_name))?;
-    } else {
-        sink.put_bytes(file_name, &bytes)
+        if let Err(err) = sink
+            .put_domain_artifact(DomainArtifactRequest {
+                rel_path: file_name,
+                name: &name,
+                data_type: &data_type,
+                existing_id: None,
+                content: DomainArtifactContent::Bytes(&bytes),
+            })
             .await
-            .with_context(|| format!("upload output {}", file_name))?;
+        {
+            warn!(
+                error = %err,
+                file = file_name,
+                "optional json output upload failed; continuing"
+            );
+        }
+    } else if let Err(err) = sink.put_bytes(file_name, &bytes).await {
+        warn!(
+            error = %err,
+            file = file_name,
+            "optional json output upload failed; continuing"
+        );
     }
     Ok(())
 }

--- a/server/rust/runner-reconstruction-local/src/refined.rs
+++ b/server/rust/runner-reconstruction-local/src/refined.rs
@@ -94,8 +94,6 @@ impl RefinedUploader {
                     uploaded.push(scan_id);
                 }
                 Err(err) => {
-                    // Refined scan zips include large optional COLMAP bins (e.g. images.bin).
-                    // Older Domain servers may reject oversized artifacts; do not fail the job.
                     warn!(
                         error = %err,
                         scan = %scan_id,

--- a/server/rust/runner-reconstruction-local/src/refined.rs
+++ b/server/rust/runner-reconstruction-local/src/refined.rs
@@ -6,7 +6,7 @@ use anyhow::{anyhow, Context, Result};
 use compute_runner_api::runner::{DomainArtifactContent, DomainArtifactRequest};
 use compute_runner_api::ArtifactSink;
 use tokio::task;
-use tracing::info;
+use tracing::{info, warn};
 use walkdir::WalkDir;
 use zip::{write::FileOptions, CompressionMethod, ZipWriter};
 
@@ -81,22 +81,28 @@ impl RefinedUploader {
             };
 
             match sink.put_domain_artifact(req).await {
-                Ok(_) => {}
+                Ok(_) => {
+                    self.completed.insert(scan_id.clone());
+                    uploaded.push(scan_id);
+                }
+                Err(err) if is_conflict_err(&err) => {
+                    info!(
+                        scan = %scan_id,
+                        "refined scan already exists in domain (409); skipping upload"
+                    );
+                    self.completed.insert(scan_id.clone());
+                    uploaded.push(scan_id);
+                }
                 Err(err) => {
-                    if is_conflict_err(&err) {
-                        info!(
-                            scan = %scan_id,
-                            "refined scan already exists in domain (409); skipping upload"
-                        );
-                    } else {
-                        return Err(err)
-                            .with_context(|| format!("upload refined scan {}", scan_id));
-                    }
+                    // Refined scan zips include large optional COLMAP bins (e.g. images.bin).
+                    // Older Domain servers may reject oversized artifacts; do not fail the job.
+                    warn!(
+                        error = %err,
+                        scan = %scan_id,
+                        "refined scan upload failed; continuing without this artifact"
+                    );
                 }
             }
-
-            self.completed.insert(scan_id.clone());
-            uploaded.push(scan_id);
         }
 
         Ok(uploaded)


### PR DESCRIPTION
Fix issue where the failing upload of optional outputs still marked the job as failed.

Background: When reconstruction large domains, the resulting images.bin from the global refinement gets big, up to a few GB. This normally gets uploaded using multipart, but if the domain is on a domain server version where multipart was not yet added, e.g. 0.8.4 where this bug was found, the server rejects too large files.

For large domains + older domain server the upload fails. This is known and expected, and one of the reasons the images.bin is marked as "mandatory: false". However "optional" only applied to if the file was never created by the python code. In this case the file was created but upload failed.

IMPORTANT NOTE: once merged back to develop, this same fix needs to be also applied to the update-refinement capability, which is not on this branch yet.

This PR branches out from the commit of 0.3.3 release, and is going to be released as 0.3.4 to hotfix this issue. Newer commits on develop will still wait for the upcoming 0.4.0 release.